### PR TITLE
[FIX] l10n_ar_pos_einvoice_ticket: comprobantes emitidos a consumidores finales o exentos (comprobantes B) t#2429

### DIFF
--- a/l10n_ar_pos_einvoice_ticket/static/src/js/pos_model.js
+++ b/l10n_ar_pos_einvoice_ticket/static/src/js/pos_model.js
@@ -42,6 +42,17 @@ odoo.define('l10n_ar_pos_einvoice_ticket', function (require) {
             if (this.pos.config.default_partner_id) {
             	this.set_client(this.pos.db.get_partner_by_id(this.pos.config.default_partner_id[0]));
             }
+            // Buscar el ID del 'l10n_ar.afip.responsibility.type' de Consumidor final
+            var self = this;
+            rpc.query({
+                model: 'l10n_ar.afip.responsibility.type',
+                method: 'search_read',
+                args: [[['code', '=', '5']]],
+            }).then(function(result) {
+                if (result.length > 0) {
+                    self.general_customer_id = result[0].id;
+                }
+            });
         },
         init_from_JSON: function (json) {
             var res = _super_Order.init_from_JSON.apply(this, arguments);

--- a/l10n_ar_pos_einvoice_ticket/static/src/xml/pos_ticket.xml
+++ b/l10n_ar_pos_einvoice_ticket/static/src/xml/pos_ticket.xml
@@ -212,6 +212,39 @@
                 </t>
             </div>
         </xpath>
+        <!-- FASE I: regimen de transparencia fiscal al consumidor 
+        Los comprobantes emitidos a consumidores finales o exentos (comprobantes B) por parte 
+        de los responsables inscriptos deberán discriminar el Impuesto al Valor Agregado (IVA)
+        y otros impuestos indirectos Nacionales.-->
+        <xpath expr="//div[@class='pos-receipt-amount']" position="after">
+            <t t-set="general_customer" t-value="receipt.client.l10n_ar_afip_responsibility_type_id == env.pos.get_order().general_customer_id"/>
+            <t t-if="env.pos.get_order().invoice_letter == 'B' or general_customer">
+                <hr />
+                <div style="font-size:8pt !important">
+                    <strong>RÉGIMEN DE TRANSPARENCIA FISCAL AL CONSUMIDOR</strong>
+                </div>
+                <div style="font-size:10pt !important">
+                    <t t-foreach="receipt.tax_details" t-as="tax">
+                        <div t-if="tax.name.substring(0, 3) === 'IVA'">
+                            <span t-esc="tax.name" />
+                            <span t-esc="env.pos.format_currency_no_symbol(tax.amount)" class="pos-receipt-right-align"/>
+                        </div>
+                    </t>
+                </div>
+                <div style="font-size:10pt !important">
+                    <span>Otros tributos nac. que inciden en el precio</span>
+                </div>
+                <div style="font-size:10pt !important">
+                    <t t-foreach="receipt.tax_details" t-as="tax">
+                        <div t-if="tax.name.substring(0, 3) !== 'IVA'">
+                            <span t-esc="tax.name" />
+                            <span t-esc="env.pos.format_currency_no_symbol(tax.amount)" class="pos-receipt-right-align"/>
+                        </div>
+                    </t>
+                </div>
+                <hr />
+            </t>
+        </xpath>
         <xpath expr="//t[@t-if='isTaxIncluded']" position="replace">
         </xpath>
         <xpath expr="//t[@t-if='!isTaxIncluded']" position="replace">


### PR DESCRIPTION
La Resolución General (ARCA) 5614/2024 establece que:
Los comprobantes emitidos a consumidores finales o exentos (comprobantes B) por parte de los responsables inscriptos
deberán discriminar el Impuesto al Valor Agregado (IVA) y otros impuestos indirectos Nacionales.
A partir del 1° de Abril de 2025, deberán discriminar los impuestos al valor agregado e internos.

![image](https://github.com/user-attachments/assets/a02d8c5c-1746-4d9a-9d38-f0ed4f81440b)
